### PR TITLE
feat: modify minter

### DIFF
--- a/contracts/alliance-nft-minter/src/contract/query.rs
+++ b/contracts/alliance-nft-minter/src/contract/query.rs
@@ -1,28 +1,33 @@
 use alliance_nft_packages::query::QueryMinterMsg;
-use alliance_nft_packages::state::{MinterConfig, MinterStats};
+use alliance_nft_packages::state::{MinterConfig, MinterStats, MinterExtension};
 use cosmwasm_std::{entry_point, to_binary};
 use cosmwasm_std::{Binary, Deps, Env, StdResult};
 
-use crate::state::{CONFIG, STATS};
-
+use crate::state::{CONFIG, NFT_METADATA, STATS};
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMinterMsg) -> StdResult<Binary> {
     match msg {
         QueryMinterMsg::Config {} => to_binary(&query_config(deps)?),
         QueryMinterMsg::Stats {} => to_binary(&query_stats(deps)?),
+        QueryMinterMsg::NftData(address) => to_binary(&query_nft_data(deps, address)?),
     }
 }
 
-fn query_config(deps : Deps) -> StdResult<MinterConfig>{
+fn query_config(deps: Deps) -> StdResult<MinterConfig> {
     let res = CONFIG.load(deps.storage)?;
 
     Ok(res)
 }
 
-
-fn query_stats(deps : Deps) -> StdResult<MinterStats>{
+fn query_stats(deps: Deps) -> StdResult<MinterStats> {
     let res = STATS.load(deps.storage)?;
 
     Ok(res)
+}
+
+fn query_nft_data(deps: Deps, address: String) -> StdResult<MinterExtension> {
+    let minter_stats = NFT_METADATA.load(deps.storage, address)?;
+
+    Ok(minter_stats)
 }

--- a/contracts/alliance-nft-minter/src/tests/execute.rs
+++ b/contracts/alliance-nft-minter/src/tests/execute.rs
@@ -1,9 +1,9 @@
-use crate::contract::{query::query, execute::execute};
+use crate::contract::{execute::execute, query::query};
 use crate::tests::helpers::append_nft_metadata_execution;
-use alliance_nft_packages::Extension;
-use alliance_nft_packages::execute::{ExecuteMinterMsg, MintMsg, ExecuteCollectionMsg};
+use alliance_nft_packages::execute::{ExecuteCollectionMsg, ExecuteMinterMsg, MintMsg};
 use alliance_nft_packages::query::QueryMinterMsg;
 use alliance_nft_packages::state::{MinterStats, Trait};
+use alliance_nft_packages::Extension;
 use cosmwasm_std::testing::mock_info;
 use cosmwasm_std::{to_binary, Response, WasmMsg};
 
@@ -11,13 +11,13 @@ use super::instantiate::intantiate_with_reply;
 
 #[test]
 fn append_nft_metadata() {
-    // Create the envrionemtn with the contract
+    // Create the env with the contract
     let (mut deps, env, _) = intantiate_with_reply();
 
     // Execute the message
     let res = append_nft_metadata_execution(
         deps.as_mut(),
-        "creator", // read this with epic voice
+        "creator", 
         "terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je".to_string(),
     );
 
@@ -44,7 +44,7 @@ fn append_nft_metadata() {
 
 #[test]
 fn append_nft_metadata_unauthorized() {
-    // Create the envrionemtn with the contract
+    // Create the env with the contract
     let (mut deps, env, _) = intantiate_with_reply();
 
     // Execute the message
@@ -56,8 +56,10 @@ fn append_nft_metadata_unauthorized() {
 
     // assert the message error
     assert_eq!(
-        res.unwrap_err().to_string(), 
-        String::from("Unauthorized execution, sender (random_address) is not the expected address (creator)")
+        res.unwrap_err().to_string(),
+        String::from(
+            "Unauthorized execution, sender (random_address) is not the expected address (creator)"
+        )
     );
 
     // query to see if stats match
@@ -74,7 +76,7 @@ fn append_nft_metadata_unauthorized() {
 
 #[test]
 fn append_nft_metadata_duplicated_error() {
-    // Create the envrionemtn with the contract
+    // Create the env with the contract
     let (mut deps, env, _) = intantiate_with_reply();
 
     // Execute the message
@@ -102,8 +104,10 @@ fn append_nft_metadata_duplicated_error() {
 
     // assert the message error
     assert_eq!(
-        res.unwrap_err().to_string(), 
-        String::from("Address terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je already exists in minters list")
+        res.unwrap_err().to_string(),
+        String::from(
+            "Address terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je already exists in minters list"
+        )
     );
     // query to see if stats match
     let query_res = query(deps.as_ref(), env, QueryMinterMsg::Stats {}).unwrap();
@@ -119,7 +123,7 @@ fn append_nft_metadata_duplicated_error() {
 
 #[test]
 fn mint_nft() {
-    // Create the envrionemtn with the contract
+    // Create the env with the contract
     let (mut deps, env, _) = intantiate_with_reply();
 
     // Execute the message
@@ -143,12 +147,12 @@ fn mint_nft() {
         deps.as_mut(),
         env.clone(),
         mock_info("terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je", &[]),
-        ExecuteMinterMsg::Mint{},
+        ExecuteMinterMsg::Mint {},
     );
 
     // assert message response
     let mint_msg = WasmMsg::Execute {
-        contract_addr:"nft_collection_address".to_string(),
+        contract_addr: "nft_collection_address".to_string(),
         msg: to_binary(&ExecuteCollectionMsg::Mint(MintMsg {
             token_id: "1".to_string(),
             owner: "terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je".to_string(),
@@ -168,7 +172,8 @@ fn mint_nft() {
                 youtube_url: None,
             },
             token_uri: None,
-        })).unwrap(),
+        }))
+        .unwrap(),
         funds: vec![],
     };
     assert_eq!(
@@ -192,14 +197,14 @@ fn mint_nft() {
 
 #[test]
 fn mint_inexistent_nft() {
-    // Create the envrionemtn with the contract
+    // Create the env with the contract
     let (mut deps, env, _) = intantiate_with_reply();
     // mint an nft
     let res = execute(
         deps.as_mut(),
         env.clone(),
         mock_info("terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je", &[]),
-        ExecuteMinterMsg::Mint{},
+        ExecuteMinterMsg::Mint {},
     );
     assert_eq!(
         res.unwrap_err().to_string(),
@@ -220,7 +225,7 @@ fn mint_inexistent_nft() {
 
 #[test]
 fn mint_outside_allowed_time() {
-    // Create the envrionemtn with the contract
+    // Create the env with the contract
     let (mut deps, mut env, _) = intantiate_with_reply();
     // increment the time with 2 secs
     env.block.time = env.block.time.plus_seconds(2);
@@ -229,7 +234,7 @@ fn mint_outside_allowed_time() {
         deps.as_mut(),
         env.clone(),
         mock_info("terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je", &[]),
-        ExecuteMinterMsg::Mint{},
+        ExecuteMinterMsg::Mint {},
     );
     assert_eq!(
         res.unwrap_err().to_string(),
@@ -242,7 +247,7 @@ fn mint_outside_allowed_time() {
         deps.as_mut(),
         env.clone(),
         mock_info("terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je", &[]),
-        ExecuteMinterMsg::Mint{},
+        ExecuteMinterMsg::Mint {},
     );
     assert_eq!(
         res.unwrap_err().to_string(),
@@ -261,10 +266,9 @@ fn mint_outside_allowed_time() {
     );
 }
 
-
 #[test]
 fn send_to_dao_treasury() {
-    // Create the envrionemtn with the contract
+    // Create the env with the contract
     let (mut deps, mut env, _) = intantiate_with_reply();
     // add 4 seconds to end time
     env.block.time = env.block.time.plus_seconds(4);
@@ -275,7 +279,6 @@ fn send_to_dao_treasury() {
         "creator", // read this with epic voice
         "terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je".to_string(),
     );
-
 
     // assert the message response
     assert_eq!(
@@ -296,7 +299,7 @@ fn send_to_dao_treasury() {
 
     // assert message response
     let mint_msg = WasmMsg::Execute {
-        contract_addr:"nft_collection_address".to_string(),
+        contract_addr: "nft_collection_address".to_string(),
         msg: to_binary(&ExecuteCollectionMsg::Mint(MintMsg {
             token_id: "1".to_string(),
             owner: "dao_treasury_address".to_string(),
@@ -316,16 +319,14 @@ fn send_to_dao_treasury() {
                 youtube_url: None,
             },
             token_uri: None,
-        })).unwrap(),
+        }))
+        .unwrap(),
         funds: vec![],
     };
     assert_eq!(
         res.unwrap(),
         Response::default()
-            .add_attributes([
-                ("method", "try_send_to_dao_treasury"),
-                ("nfts_send", "1")]
-            )
+            .add_attributes([("method", "try_send_to_dao_treasury"), ("nfts_send", "1")])
             .add_messages([mint_msg])
     );
 
@@ -343,7 +344,7 @@ fn send_to_dao_treasury() {
 
 #[test]
 fn send_to_dao_before_end_time() {
-    // Create the envrionemtn with the contract
+    // Create the env with the contract
     let (mut deps, env, _) = intantiate_with_reply();
 
     // Execute the message
@@ -352,7 +353,6 @@ fn send_to_dao_before_end_time() {
         "creator", // read this with epic voice
         "terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je".to_string(),
     );
-
 
     // assert the message response
     assert_eq!(
@@ -370,7 +370,7 @@ fn send_to_dao_before_end_time() {
         mock_info("terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je", &[]),
         ExecuteMinterMsg::SendToDao(2),
     );
-    
+
     assert_eq!(
         res.unwrap_err().to_string(),
         String::from("NFTs cannot be send to DAO yet, current time is 2.000000000 and mint end time is 3.000000000")
@@ -385,5 +385,86 @@ fn send_to_dao_before_end_time() {
             minted_nfts: 0,
         })
         .unwrap()
+    );
+}
+
+#[test]
+fn test_try_change_dao_treasury_address_with_random_acc() {
+    // Create the env with the contract
+    let (mut deps, env, _) = intantiate_with_reply();
+
+    // Execute the message
+    let res = execute(
+        deps.as_mut(),
+        env.clone(),
+        mock_info("das_ist_keine_owner", &[]),
+        ExecuteMinterMsg::ChangeDaoTreasuryAddress(
+            "terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je".to_string(),
+        ),
+    );
+
+    // assert the message response
+    assert_eq!(
+        res.unwrap_err().to_string(),
+        String::from("Unauthorized execution, sender (das_ist_keine_owner) is not the expected address (creator)")
+    );
+}
+
+#[test]
+fn test_try_change_dao_treasury_address_with_creator() {
+    // Create the env with the contract
+    let (mut deps, env, _) = intantiate_with_reply();
+
+    // Execute the message
+    let res = execute(
+        deps.as_mut(),
+        env.clone(),
+        mock_info("creator", &[]),
+        ExecuteMinterMsg::ChangeDaoTreasuryAddress(
+            "terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je".to_string(),
+        ),
+    );
+
+    // assert the message response
+    assert_eq!(
+        res.unwrap(),
+        Response::default()
+            .add_attribute("method", "try_change_dao_treasury_address")
+            .add_attribute(
+                "new_dao_treasury_address",
+                "terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je"
+            ),
+    );
+}
+
+#[test]
+fn test_try_change_owener() {
+    // Create the env with the contract
+    let (mut deps, env, _) = intantiate_with_reply();
+
+    // Execute the message
+    let res = execute(
+        deps.as_mut(),
+        env.clone(),
+        mock_info("creator", &[]),
+        ExecuteMinterMsg::ChangeOwner("terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je".to_string()),
+    );
+
+    // assert the message response
+    assert_eq!(
+        res.unwrap(),
+        Response::default()
+            .add_attributes(vec![
+                ("action", "change_owner"),
+                ("new_owner", "terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je"),
+            ])
+            .add_message(WasmMsg::Execute {
+                contract_addr: "nft_collection_address".to_string(),
+                msg: to_binary(&ExecuteCollectionMsg::ChangeOwner(
+                    "terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je".to_string()
+                ))
+                .unwrap(),
+                funds: vec![],
+            })
     );
 }

--- a/contracts/alliance-nft-minter/src/tests/instantiate.rs
+++ b/contracts/alliance-nft-minter/src/tests/instantiate.rs
@@ -21,16 +21,14 @@ fn test_instantiate() {
     let res = query(deps.as_ref(), env, QueryMinterMsg::Config {}).unwrap();
 
     assert_eq!(
-        res,
+        res.to_string(),
         to_binary(&MinterConfig {
-            dao_address: Addr::unchecked("dao_address"),
-            dao_treasury_address: Addr::unchecked("dao_treasury_address"),
-            nft_collection_address: Addr::unchecked("nft_collection_address"),
+            dao_treasury_address: Some(Addr::unchecked("dao_treasury_address")),
+            nft_collection_address: Some(Addr::unchecked("nft_collection_address")),
             owner: Addr::unchecked("creator"),
             mint_start_time: Timestamp::from_seconds(1),
             mint_end_time: Timestamp::from_seconds(3),
-        })
-        .unwrap()
+        }).unwrap().to_string()
     );
 }
 
@@ -44,8 +42,7 @@ fn test_instantiate_wrong_time_range() {
 
     // WHEN instantiating the contract ...
     let msg = InstantiateMinterMsg {
-        dao_address: Addr::unchecked("dao_address"),
-        dao_treasury_address: Addr::unchecked("dao_treasury_address"),
+        dao_treasury_address: Some(Addr::unchecked("dao_treasury_address")),
         nft_collection_code_id: 1,
         mint_start_time: Timestamp::from_seconds(3),
         mint_end_time: Timestamp::from_seconds(1),
@@ -72,8 +69,7 @@ pub fn intantiate_with_reply() -> (
 
     // WHEN instantiating the contract ...
     let msg = InstantiateMinterMsg {
-        dao_address: Addr::unchecked("dao_address"),
-        dao_treasury_address: Addr::unchecked("dao_treasury_address"),
+        dao_treasury_address: Some(Addr::unchecked("dao_treasury_address")),
         nft_collection_code_id: 1,
         mint_start_time: Timestamp::from_seconds(1),
         mint_end_time: Timestamp::from_seconds(3),
@@ -94,7 +90,7 @@ pub fn intantiate_with_reply() -> (
                 name: "AllianceDAO".to_string(),
                 symbol: "ALLIANCE".to_string(),
                 minter: env.contract.address.to_string(),
-                owner: Addr::unchecked("dao_address"),
+                owner: Addr::unchecked("creator"),
             })
             .unwrap(),
             funds: vec![],

--- a/packages/alliance-nft-packages/src/errors.rs
+++ b/packages/alliance-nft-packages/src/errors.rs
@@ -44,5 +44,15 @@ pub enum ContractError {
     AlreadyExists(String),
 
     #[error("No available NFTs to be minted")]
-    NoAvailableNfts {}
+    NoAvailableNfts {},
+    
+    #[error("DAO Address must be set")]
+    DaoAddressNotSet{},
+
+    #[error("Dao treasury address must be set")]
+    DaoTreasuryAddressNotSet{},
+    
+    #[error("Nft collection address must be set")]
+    NftCollectionAddressNotSet{},
+
 }

--- a/packages/alliance-nft-packages/src/execute.rs
+++ b/packages/alliance-nft-packages/src/execute.rs
@@ -31,6 +31,7 @@ pub enum ExecuteCollectionMsg {
     AllianceRedelegate(AllianceRedelegateMsg),
     AllianceClaimRewards {},
     UpdateRewardsCallback {},
+    ChangeOwner(String),
 
     // Claim the accumulated rewards and send them to the owner
     // while the NFT is broken it will not accumulate rewards
@@ -150,4 +151,6 @@ pub enum ExecuteMinterMsg {
     AppendNftMetadata(HashMap<String, MinterExtension>),
     Mint {},
     SendToDao(i16),
+    ChangeDaoTreasuryAddress(String),
+    ChangeOwner(String),
 }

--- a/packages/alliance-nft-packages/src/instantiate.rs
+++ b/packages/alliance-nft-packages/src/instantiate.rs
@@ -22,8 +22,7 @@ impl From<InstantiateCollectionMsg> for CW721InstantiateMsg {
 
 #[cw_serde]
 pub struct InstantiateMinterMsg {
-    pub dao_address: Addr,
-    pub dao_treasury_address: Addr,
+    pub dao_treasury_address: Option<Addr>,
     pub nft_collection_code_id: u64,
     pub mint_start_time: Timestamp,
     pub mint_end_time: Timestamp,

--- a/packages/alliance-nft-packages/src/query.rs
+++ b/packages/alliance-nft-packages/src/query.rs
@@ -1,5 +1,5 @@
 use super::Extension;
-use crate::state::{Config as ConfigRes, MinterConfig, MinterStats};
+use crate::state::{Config as ConfigRes, MinterConfig, MinterStats, MinterExtension};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Empty;
 use cw721::{
@@ -205,4 +205,6 @@ pub enum QueryMinterMsg {
     Config {},
     #[returns(MinterStats)]
     Stats {},
+    #[returns(MinterExtension)]
+    NftData(String),
 }

--- a/packages/alliance-nft-packages/src/state.rs
+++ b/packages/alliance-nft-packages/src/state.rs
@@ -33,9 +33,8 @@ pub struct Config {
 #[cw_serde]
 pub struct MinterConfig {
     pub owner: Addr,
-    pub dao_address: Addr,
-    pub dao_treasury_address: Addr,
-    pub nft_collection_address: Addr,
+    pub dao_treasury_address: Option<Addr>,
+    pub nft_collection_address: Option<Addr>,
     pub mint_start_time: Timestamp,
     pub mint_end_time: Timestamp,
 }
@@ -43,8 +42,6 @@ pub struct MinterConfig {
 impl MinterConfig {
     pub fn new_partial(
         owner: Addr,
-        dao_address: Addr,
-        dao_treasury_address: Addr,
         mint_start_time: Timestamp,
         mint_end_time: Timestamp,
     ) -> MinterConfig {
@@ -52,9 +49,8 @@ impl MinterConfig {
             owner,
             mint_start_time,
             mint_end_time,
-            dao_address,
-            dao_treasury_address,
-            nft_collection_address: Addr::unchecked(""),
+            dao_treasury_address : None,
+            nft_collection_address : None,
         }
     }
 
@@ -67,7 +63,8 @@ impl MinterConfig {
     }
 
     // check if the block time is between start and end time
-    pub fn is_mint_enabled(&self, current_time: Timestamp) -> Result<Response, ContractError> {
+    // and the other params are set correctly
+    pub fn is_minting_period(&self, current_time: Timestamp) -> Result<Response, ContractError> {
         if current_time < self.mint_start_time || current_time > self.mint_end_time {
             return Err(ContractError::MintTimeCompleted(
                 self.mint_start_time,
@@ -80,7 +77,7 @@ impl MinterConfig {
     }
 
     // check if the block time is after end time
-    pub fn is_send_to_dao_enabled(&self, time: Timestamp) -> Result<Response, ContractError> {
+    pub fn has_minting_period_finish(&self, time: Timestamp) -> Result<Response, ContractError> {
         if time < self.mint_end_time {
             return Err(ContractError::CannotSendToDao(time, self.mint_end_time));
         }


### PR DESCRIPTION
Since the mint is independent to Enterprise DAO, we need to be able to modify the owner and the treasury address of the Mint contract which derives on many other changes listed here:
- not allowing minting without information about the owner or treasury address, 
- remove the dao address (since is not needed anymore),
- change owner method for the Minter must also change the owner of AllianceNftCollection.

Besides has been addeda query to check if a specific address has an nft allowed to be claimed.

Some code has been clean to use optionals instead of empty addresses and tests have been written to increase code coverage.